### PR TITLE
chore: update json import assertion to use with syntax

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createEnv } from 'yeoman-environment';
-import npm from './package.json' assert { type: 'json' };
+import npm from './package.json' with { type: 'json' };
 
 console.log(`generator-bitloops v${npm.version}`);
 
@@ -19,7 +19,7 @@ const env = createEnv();
 (async () => {
   // Dynamically import the subgenerator path
   const generatorPath = await import(`./${subgenerator}/index.js`);
-  
+
   // Register your generator
   env.register(generatorPath.default, `bitloops:${subgenerator}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-bitloops",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-bitloops",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "license": "MIT",
       "dependencies": {
         "yeoman-environment": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-bitloops",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Next.js with TypeScript, Tailwind, Storybook and Cypress generator by Bitloops",
   "license": "MIT",
   "author": "Bitloops S.A.",


### PR DESCRIPTION
New syntax while working for node versions >= `22`, breaks compatibility with node <`17`. Storybook needs node >=20 anyway, so not a dealbreaker for us.